### PR TITLE
Keyboard shortcuts for browser intercepted by snap (fixed)

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -2284,9 +2284,9 @@ IDE_Morph.prototype.projectMenu = function () {
     menu = new MenuMorph(this);
     menu.addItem('Project notes...', 'editProjectNotes');
     menu.addLine();
-    menu.addItem('New', 'createNewProject');
-    menu.addItem('Open...', 'openProjectsBrowser');
-    menu.addItem('Save', "save");
+    menu.addItem('New                          ctrl + n', 'createNewProject');
+    menu.addItem('Open...                 ctrl/⌘ + o', 'openProjectsBrowser');
+    menu.addItem('Save                     ctrl/⌘ + s', "save");
     if (shiftClicked) {
         menu.addItem(
             'Save to disk',
@@ -2295,7 +2295,7 @@ IDE_Morph.prototype.projectMenu = function () {
             new Color(100, 0, 0)
         );
     }
-    menu.addItem('Save As...', 'saveProjectsBrowser');
+    menu.addItem('Save As...  ctrl/⌘ + shift + s', 'saveProjectsBrowser');
     menu.addLine();
     menu.addItem(
         'Import...',

--- a/morphic.js
+++ b/morphic.js
@@ -10321,8 +10321,10 @@ WorldMorph.prototype.initEventListeners = function () {
                 }
                 event.preventDefault();
             }
+            // disables browser shortcuts when conflicting with snap shortcuts
+            var shortcuts = ['U+0053', 'U+004F', 'U+004E', 'U+0046']
             if ((event.ctrlKey || event.metaKey) &&
-                    (event.keyIdentifier !== 'U+0056')) { // allow pasting-in
+                    (shortcuts.indexOf(event.keyIdentifier)) !== -1) {
                 event.preventDefault();
             }
         },

--- a/roster.txt
+++ b/roster.txt
@@ -10,4 +10,6 @@ Thanks!
 
 ADD YOUR CODE *ahem* NAME HERE
 
+Lucas Karahadian (jeeves833)
+
 


### PR DESCRIPTION
In Morphic.js, I added a list containing unicode representations of "n", "o", "s", and "f", the only keyboard shortcuts that would present conflicts between Snap and the browser.  Now, whenever Snap receives a ctrl+some button command, it will check if this command is in our list of shortcuts.  If the code is not in the shortcuts, it will pass the command on to the browser.  In addition, Snap now has text in its drop-down menus detailing the keyboard shortcuts it supports.
